### PR TITLE
Decompressed Stream Support

### DIFF
--- a/src/stream/brotli.rs
+++ b/src/stream/brotli.rs
@@ -2,9 +2,9 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-use std::io::Result;
+use std::io::{Error, ErrorKind, Result};
 
-use brotli2::raw::{CoStatus, CompressOp};
+use brotli2::raw::{CoStatus, CompressOp, DeStatus, Decompress};
 pub use brotli2::{raw::Compress, CompressParams};
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::{ready, stream::Stream};
@@ -69,6 +69,70 @@ impl<S: Stream<Item = Result<Bytes>>> BrotliStream<S> {
             inner: stream,
             flushing: false,
             compress,
+        }
+    }
+}
+
+#[unsafe_project(Unpin)]
+pub struct DecompressedBrotliStream<S: Stream<Item = Result<Bytes>>> {
+    #[pin]
+    inner: S,
+    flushing: bool,
+    decompress: Decompress,
+}
+
+impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedBrotliStream<S> {
+    type Item = Result<Bytes>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
+        const OUTPUT_BUFFER_SIZE: usize = 8_000;
+
+        let this = self.project();
+
+        if *this.flushing {
+            return Poll::Ready(None);
+        }
+
+        let input_buffer = if let Some(bytes) = ready!(this.inner.poll_next(cx)) {
+            bytes?
+        } else {
+            *this.flushing = true;
+            Bytes::new()
+        };
+
+        let mut decompressed_output = BytesMut::with_capacity(OUTPUT_BUFFER_SIZE);
+        let input_ref = &mut input_buffer.as_ref();
+        let output_ref = &mut &mut [][..];
+        loop {
+            let status = this.decompress.decompress(input_ref, output_ref)?;
+            while let Some(buf) = this.decompress.take_output(None) {
+                decompressed_output.put(buf);
+            }
+            match status {
+                DeStatus::Finished => break,
+                DeStatus::NeedInput => {
+                    if *this.flushing {
+                        return Poll::Ready(Some(Err(Error::new(
+                            ErrorKind::UnexpectedEof,
+                            "reached unexpected EOF",
+                        ))));
+                    }
+                    break;
+                }
+                DeStatus::NeedOutput => (),
+            }
+        }
+
+        Poll::Ready(Some(Ok(decompressed_output.freeze())))
+    }
+}
+
+impl<S: Stream<Item = Result<Bytes>>> DecompressedBrotliStream<S> {
+    pub fn new(stream: S) -> DecompressedBrotliStream<S> {
+        DecompressedBrotliStream {
+            inner: stream,
+            flushing: false,
+            decompress: Decompress::new(),
         }
     }
 }

--- a/src/stream/brotli.rs
+++ b/src/stream/brotli.rs
@@ -77,7 +77,7 @@ impl<S: Stream<Item = Result<Bytes>>> BrotliStream<S> {
 pub struct DecompressedBrotliStream<S: Stream<Item = Result<Bytes>>> {
     #[pin]
     inner: S,
-    flushing: bool,
+    flush: bool,
     decompress: Decompress,
 }
 
@@ -85,46 +85,45 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedBrotliStream<S> {
     type Item = Result<Bytes>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
-//        const OUTPUT_BUFFER_SIZE: usize = 8_000;
-//
-//        let this = self.project();
-//
-//        if *this.flushing {
-//            return Poll::Ready(None);
-//        }
-//
-//        let input_buffer = if let Some(bytes) = ready!(this.inner.poll_next(cx)) {
-//            bytes?
-//        } else {
-//            *this.flushing = true;
-//            Bytes::new()
-//        };
-//
-//        let mut decompressed_output = BytesMut::with_capacity(OUTPUT_BUFFER_SIZE);
-//        let input_ref = &mut input_buffer.as_ref();
-//        let output_ref = &mut &mut [][..];
-//        loop {
-//            let status = this.decompress.decompress(input_ref, output_ref)?;
-//            while let Some(buf) = this.decompress.take_output(None) {
-//                decompressed_output.put(buf);
-//            }
-//            match status {
-//                DeStatus::Finished => break,
-//                DeStatus::NeedInput => {
-//                    if *this.flushing {
-//                        return Poll::Ready(Some(Err(Error::new(
-//                            ErrorKind::UnexpectedEof,
-//                            "reached unexpected EOF",
-//                        ))));
-//                    }
-//                    break;
-//                }
-//                DeStatus::NeedOutput => (),
-//            }
-//        }
-//
-//        Poll::Ready(Some(Ok(decompressed_output.freeze())))
-        unimplemented!()
+        const OUTPUT_BUFFER_SIZE: usize = 8_000;
+
+        let this = self.project();
+
+        if *this.flush {
+            return Poll::Ready(None);
+        }
+
+        let input_buffer = if let Some(bytes) = ready!(this.inner.poll_next(cx)) {
+            bytes?
+        } else {
+            *this.flush = true;
+            Bytes::new()
+        };
+
+        let mut decompressed_output = BytesMut::with_capacity(OUTPUT_BUFFER_SIZE);
+        let input_ref = &mut input_buffer.as_ref();
+        let output_ref = &mut &mut [][..];
+        loop {
+            let status = this.decompress.decompress(input_ref, output_ref)?;
+            while let Some(buf) = this.decompress.take_output(None) {
+                decompressed_output.extend_from_slice(buf);
+            }
+            match status {
+                DeStatus::Finished => break,
+                DeStatus::NeedInput => {
+                    if *this.flush {
+                        return Poll::Ready(Some(Err(Error::new(
+                            ErrorKind::UnexpectedEof,
+                            "reached unexpected EOF",
+                        ))));
+                    }
+                    break;
+                }
+                DeStatus::NeedOutput => (),
+            }
+        }
+
+        Poll::Ready(Some(Ok(decompressed_output.freeze())))
     }
 }
 
@@ -132,7 +131,7 @@ impl<S: Stream<Item = Result<Bytes>>> DecompressedBrotliStream<S> {
     pub fn new(stream: S) -> DecompressedBrotliStream<S> {
         DecompressedBrotliStream {
             inner: stream,
-            flushing: false,
+            flush: false,
             decompress: Decompress::new(),
         }
     }

--- a/src/stream/deflate.rs
+++ b/src/stream/deflate.rs
@@ -5,9 +5,9 @@ use core::{
 use std::io::Result;
 use std::marker::Unpin;
 
-use super::flate::CompressedStream;
+use super::flate::{CompressedStream, DecompressedStream};
 use bytes::Bytes;
-use flate2::Compress;
+use flate2::{Compress, Decompress};
 pub use flate2::Compression;
 use futures::{stream::Stream, stream::StreamExt};
 
@@ -27,6 +27,26 @@ impl<S: Stream<Item = Result<Bytes>> + Unpin> DeflateStream<S> {
     pub fn new(stream: S, level: Compression) -> DeflateStream<S> {
         DeflateStream {
             inner: CompressedStream::new(stream, Compress::new(level, false)),
+        }
+    }
+}
+
+pub struct DecompressedDeflateStream<S: Stream<Item = Result<Bytes>> + Unpin> {
+    inner: DecompressedStream<S>,
+}
+
+impl<S: Stream<Item = Result<Bytes>> + Unpin> Stream for DecompressedDeflateStream<S> {
+    type Item = Result<Bytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+impl<S: Stream<Item = Result<Bytes>> + Unpin> DecompressedDeflateStream<S> {
+    pub fn new(stream: S) -> DecompressedDeflateStream<S> {
+        DecompressedDeflateStream {
+            inner: DecompressedStream::new(stream, Decompress::new(false)),
         }
     }
 }

--- a/src/stream/deflate.rs
+++ b/src/stream/deflate.rs
@@ -7,8 +7,8 @@ use std::marker::Unpin;
 
 use super::flate::{CompressedStream, DecompressedStream};
 use bytes::Bytes;
-use flate2::{Compress, Decompress};
 pub use flate2::Compression;
+use flate2::{Compress, Decompress};
 use futures::{stream::Stream, stream::StreamExt};
 
 pub struct DeflateStream<S: Stream<Item = Result<Bytes>> + Unpin> {

--- a/src/stream/flate.rs
+++ b/src/stream/flate.rs
@@ -5,8 +5,8 @@ use core::{
 use std::io::Result;
 
 use bytes::{Bytes, BytesMut};
-use flate2::FlushCompress;
-pub use flate2::{Compress, Compression};
+use flate2::{FlushCompress, FlushDecompress};
+pub use flate2::{Compress, Compression, Decompress};
 use futures::{ready, stream::Stream};
 use pin_project::unsafe_project;
 
@@ -68,6 +68,68 @@ impl<S: Stream<Item = Result<Bytes>>> CompressedStream<S> {
             input_buffer: Bytes::new(),
             output_buffer: BytesMut::new(),
             compress,
+        }
+    }
+}
+
+#[unsafe_project(Unpin)]
+pub struct DecompressedStream<S: Stream<Item = Result<Bytes>>> {
+    #[pin]
+    inner: S,
+    flushing: bool,
+    input_buffer: Bytes,
+    output_buffer: BytesMut,
+    decompress: Decompress,
+}
+
+impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedStream<S> {
+    type Item = Result<Bytes>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
+        const OUTPUT_BUFFER_SIZE: usize = 8_000;
+
+        let this = self.project();
+
+        if this.input_buffer.is_empty() {
+            if *this.flushing {
+                return Poll::Ready(None);
+            } else if let Some(bytes) = ready!(this.inner.poll_next(cx)) {
+                *this.input_buffer = bytes?;
+            } else {
+                *this.flushing = true;
+            }
+        }
+
+        this.output_buffer.resize(OUTPUT_BUFFER_SIZE, 0);
+
+        let flush = if *this.flushing {
+            FlushDecompress::Finish
+        } else {
+            FlushDecompress::None
+        };
+
+        let (prior_in, prior_out) = (this.decompress.total_in(), this.decompress.total_out());
+        this.decompress
+            .decompress(this.input_buffer, this.output_buffer, flush)?;
+        let input = this.decompress.total_in() - prior_in;
+        let output = this.decompress.total_out() - prior_out;
+
+        this.input_buffer.advance(input as usize);
+        Poll::Ready(Some(Ok(this
+            .output_buffer
+            .split_to(output as usize)
+            .freeze())))
+    }
+}
+
+impl<S: Stream<Item = Result<Bytes>>> DecompressedStream<S> {
+    pub fn new(stream: S, decompress: Decompress) -> DecompressedStream<S> {
+        DecompressedStream {
+            inner: stream,
+            flushing: false,
+            input_buffer: Bytes::new(),
+            output_buffer: BytesMut::new(),
+            decompress,
         }
     }
 }

--- a/src/stream/flate.rs
+++ b/src/stream/flate.rs
@@ -94,7 +94,7 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedStream<S> {
             if *this.flushing {
                 return Poll::Ready(None);
             } else if let Some(bytes) = ready!(this.inner.poll_next(cx)) {
-                *this.input_buffer = bytes?;
+                this.input_buffer.extend_from_slice(&bytes?);
             } else {
                 *this.flushing = true;
             }

--- a/src/stream/flate.rs
+++ b/src/stream/flate.rs
@@ -5,8 +5,8 @@ use core::{
 use std::io::Result;
 
 use bytes::{Bytes, BytesMut};
-use flate2::{FlushCompress, FlushDecompress};
 pub use flate2::{Compress, Compression, Decompress};
+use flate2::{FlushCompress, FlushDecompress};
 use futures::{ready, stream::Stream};
 use pin_project::unsafe_project;
 

--- a/src/stream/flate.rs
+++ b/src/stream/flate.rs
@@ -189,7 +189,7 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedStream<S> {
 
                     *this.state = match status {
                         Status::Ok => State::Writing(input),
-                        Status::StreamEnd => unreachable!(),
+                        Status::StreamEnd => State::Reading,
                         Status::BufError => panic!("unexpected BufError"),
                     };
 

--- a/src/stream/flate.rs
+++ b/src/stream/flate.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use bytes::{Bytes, BytesMut};
-pub(crate) use flate2::Compress;
-use flate2::{FlushCompress, FlushDecompress, Status, Decompress};
+pub(crate) use flate2::{Compress, Decompress};
+use flate2::{FlushCompress, FlushDecompress, Status};
 use futures::{ready, stream::Stream};
 use pin_project::unsafe_project;
 
@@ -127,12 +127,11 @@ impl<S: Stream<Item = Result<Bytes>>> CompressedStream<S> {
 }
 
 #[unsafe_project(Unpin)]
-pub struct DecompressedStream<S: Stream<Item = Result<Bytes>>> {
+pub(crate) struct DecompressedStream<S: Stream<Item = Result<Bytes>>> {
     #[pin]
     inner: S,
-    flushing: bool,
-    input_buffer: Bytes,
-    output_buffer: BytesMut,
+    state: State,
+    output: BytesMut,
     decompress: Decompress,
 }
 
@@ -140,49 +139,94 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedStream<S> {
     type Item = Result<Bytes>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
-        const OUTPUT_BUFFER_SIZE: usize = 8_000;
+        let mut this = self.project();
 
-        let this = self.project();
+        fn decompress(
+            decompress: &mut Decompress,
+            input: &mut Bytes,
+            output: &mut BytesMut,
+            flush: FlushDecompress,
+        ) -> Result<(Status, Bytes)> {
+            const OUTPUT_BUFFER_SIZE: usize = 8_000;
 
-        if this.input_buffer.is_empty() {
-            if *this.flushing {
-                return Poll::Ready(None);
-            } else if let Some(bytes) = ready!(this.inner.poll_next(cx)) {
-                this.input_buffer.extend_from_slice(&bytes?);
-            } else {
-                *this.flushing = true;
+            if output.len() < OUTPUT_BUFFER_SIZE {
+                output.resize(OUTPUT_BUFFER_SIZE, 0);
             }
+
+            let (prior_in, prior_out) = (decompress.total_in(), decompress.total_out());
+            let status = decompress.decompress(input, output, flush)?;
+            let input_len = decompress.total_in() - prior_in;
+            let output_len = decompress.total_out() - prior_out;
+
+            input.advance(input_len as usize);
+            Ok((status, output.split_to(output_len as usize).freeze()))
         }
 
-        this.output_buffer.resize(OUTPUT_BUFFER_SIZE, 0);
+        #[allow(clippy::never_loop)] // https://github.com/rust-lang/rust-clippy/issues/4058
+        loop {
+            break match mem::replace(this.state, State::Invalid) {
+                State::Reading => {
+                    *this.state = State::Reading;
+                    *this.state = match ready!(this.inner.as_mut().poll_next(cx)) {
+                        Some(chunk) => State::Writing(chunk?),
+                        None => State::Flushing,
+                    };
+                    continue;
+                }
 
-        let flush = if *this.flushing {
-            FlushDecompress::Finish
-        } else {
-            FlushDecompress::None
-        };
+                State::Writing(mut input) => {
+                    if input.is_empty() {
+                        *this.state = State::Reading;
+                        continue;
+                    }
 
-        let (prior_in, prior_out) = (this.decompress.total_in(), this.decompress.total_out());
-        this.decompress
-            .decompress(this.input_buffer, this.output_buffer, flush)?;
-        let input = this.decompress.total_in() - prior_in;
-        let output = this.decompress.total_out() - prior_out;
+                    let (status, chunk) = decompress(
+                        &mut this.decompress,
+                        &mut input,
+                        &mut this.output,
+                        FlushDecompress::None,
+                    )?;
 
-        this.input_buffer.advance(input as usize);
-        Poll::Ready(Some(Ok(this
-            .output_buffer
-            .split_to(output as usize)
-            .freeze())))
+                    *this.state = match status {
+                        Status::Ok => State::Writing(input),
+                        Status::StreamEnd => unreachable!(),
+                        Status::BufError => panic!("unexpected BufError"),
+                    };
+
+                    Poll::Ready(Some(Ok(chunk)))
+                }
+
+                State::Flushing => {
+                    let (status, chunk) = decompress(
+                        &mut this.decompress,
+                        &mut Bytes::new(),
+                        &mut this.output,
+                        FlushDecompress::Finish,
+                    )?;
+
+                    *this.state = match status {
+                        Status::Ok => State::Flushing,
+                        Status::StreamEnd => State::Done,
+                        Status::BufError => panic!("unexpected BufError"),
+                    };
+
+                    Poll::Ready(Some(Ok(chunk)))
+                }
+
+                State::Done => Poll::Ready(None),
+
+                State::Invalid => panic!("CompressedStream reached invalid state"),
+            };
+        }
     }
 }
 
 impl<S: Stream<Item = Result<Bytes>>> DecompressedStream<S> {
-    pub fn new(stream: S, decompress: Decompress) -> DecompressedStream<S> {
+    pub(crate) fn new(stream: S, decompress: Decompress) -> DecompressedStream<S> {
         DecompressedStream {
             inner: stream,
-            flushing: false,
-            input_buffer: Bytes::new(),
-            output_buffer: BytesMut::new(),
+            state: State::Reading,
+            output: BytesMut::new(),
             decompress,
         }
     }

--- a/src/stream/gzip.rs
+++ b/src/stream/gzip.rs
@@ -219,7 +219,7 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedGzipStream<S> {
 
         #[allow(clippy::never_loop)] // https://github.com/rust-lang/rust-clippy/issues/4058
         loop {
-            break match dbg!(mem::replace(this.state, DeState::Invalid)) {
+            break match mem::replace(this.state, DeState::Invalid) {
                 DeState::ReadingHeader => {
                     *this.state = match ready!(this.inner.as_mut().poll_next(cx)) {
                         Some(chunk) => {
@@ -249,10 +249,12 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedGzipStream<S> {
                 DeState::Reading => {
                     *this.state = match ready!(this.inner.as_mut().poll_next(cx)) {
                         Some(chunk) => {
-                            *this.input = chunk?;
+                            this.input.extend_from_slice(&chunk?);
                             DeState::Writing
                         }
-                        None => DeState::ReadingFooter,
+                        None => {
+                            DeState::ReadingFooter
+                        },
                     };
                     continue;
                 }
@@ -280,16 +282,17 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedGzipStream<S> {
                 }
 
                 DeState::ReadingFooter => {
-                    *this.state = DeState::Done;
                     if this.input.len() == 8 {
                         let crc = &this.crc.sum().to_le_bytes()[..];
                         let bytes_read = &this.crc.amount().to_le_bytes()[..];
                         if crc != &this.input[0..4] {
+                            *this.state = DeState::Done;
                             Poll::Ready(Some(Err(Error::new(
                                 ErrorKind::InvalidData,
                                 "CRC computed does not match",
                             ))))
                         } else if bytes_read != &this.input[4..8] {
+                            *this.state = DeState::Done;
                             Poll::Ready(Some(Err(Error::new(
                                 ErrorKind::InvalidData,
                                 "amount of bytes read does not match",
@@ -298,6 +301,7 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedGzipStream<S> {
                             Poll::Ready(None)
                         }
                     } else {
+                        *this.state = DeState::Done;
                         Poll::Ready(Some(Err(Error::new(
                             ErrorKind::UnexpectedEof,
                             "reached unexpected EOF",

--- a/src/stream/gzip.rs
+++ b/src/stream/gzip.rs
@@ -239,7 +239,15 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedGzipStream<S> {
                                 DeState::Writing
                             }
                         }
-                        None => DeState::CheckingFooter,
+                        None => {
+                            if !*this.header_read {
+                                return Poll::Ready(Some(Err(Error::new(
+                                    ErrorKind::InvalidData,
+                                    "A valid header was not found",
+                                ))));
+                            }
+                            DeState::CheckingFooter
+                        }
                     };
                     continue;
                 }

--- a/src/stream/gzip.rs
+++ b/src/stream/gzip.rs
@@ -249,12 +249,14 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedGzipStream<S> {
                 DeState::Reading => {
                     *this.state = match ready!(this.inner.as_mut().poll_next(cx)) {
                         Some(chunk) => {
-                            this.input.extend_from_slice(&chunk?);
+                            if this.input.is_empty() {
+                                *this.input = chunk?;
+                            } else {
+                                this.input.extend_from_slice(&chunk?);
+                            }
                             DeState::Writing
                         }
-                        None => {
-                            DeState::ReadingFooter
-                        },
+                        None => DeState::ReadingFooter,
                     };
                     continue;
                 }

--- a/src/stream/gzip.rs
+++ b/src/stream/gzip.rs
@@ -231,7 +231,7 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedGzipStream<S> {
                                         "Invalid file header",
                                     ))));
                                 }
-                                DeState::Reading
+                                DeState::Writing
                             } else {
                                 DeState::ReadingHeader
                             }
@@ -295,7 +295,10 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedGzipStream<S> {
                         }
                         Poll::Ready(None)
                     } else {
-                        unreachable!() // this should be unreachable
+                        return Poll::Ready(Some(Err(Error::new(
+                            ErrorKind::UnexpectedEof,
+                            "reached unexpected EOF",
+                        ))));
                     }
                 }
 

--- a/src/stream/gzip.rs
+++ b/src/stream/gzip.rs
@@ -165,7 +165,6 @@ impl<S: Stream<Item = Result<Bytes>>> Stream for DecompressedGzipStream<S> {
                 ))));
             }
             *this.header_stripped = true;
-            return Poll::Ready(Some(Ok(Bytes::new())));
         }
 
         this.output_buffer.resize(OUTPUT_BUFFER_SIZE, 0);

--- a/src/stream/zlib.rs
+++ b/src/stream/zlib.rs
@@ -7,8 +7,8 @@ use std::marker::Unpin;
 
 use super::flate::{CompressedStream, DecompressedStream};
 use bytes::Bytes;
-use flate2::{Compress, Decompress};
 pub use flate2::Compression;
+use flate2::{Compress, Decompress};
 use futures::{stream::Stream, stream::StreamExt};
 
 pub struct ZlibStream<S: Stream<Item = Result<Bytes>> + Unpin> {

--- a/src/stream/zlib.rs
+++ b/src/stream/zlib.rs
@@ -5,9 +5,9 @@ use core::{
 use std::io::Result;
 use std::marker::Unpin;
 
-use super::flate::CompressedStream;
+use super::flate::{CompressedStream, DecompressedStream};
 use bytes::Bytes;
-use flate2::Compress;
+use flate2::{Compress, Decompress};
 pub use flate2::Compression;
 use futures::{stream::Stream, stream::StreamExt};
 
@@ -27,6 +27,26 @@ impl<S: Stream<Item = Result<Bytes>> + Unpin> ZlibStream<S> {
     pub fn new(stream: S, level: Compression) -> ZlibStream<S> {
         ZlibStream {
             inner: CompressedStream::new(stream, Compress::new(level, true)),
+        }
+    }
+}
+
+pub struct DecompressedZlibStream<S: Stream<Item = Result<Bytes>> + Unpin> {
+    inner: DecompressedStream<S>,
+}
+
+impl<S: Stream<Item = Result<Bytes>> + Unpin> Stream for DecompressedZlibStream<S> {
+    type Item = Result<Bytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+impl<S: Stream<Item = Result<Bytes>> + Unpin> DecompressedZlibStream<S> {
+    pub fn new(stream: S) -> DecompressedZlibStream<S> {
+        DecompressedZlibStream {
+            inner: DecompressedStream::new(stream, Decompress::new(true)),
         }
     }
 }

--- a/tests/brotli.rs
+++ b/tests/brotli.rs
@@ -2,7 +2,6 @@ use brotli2::bufread::BrotliDecoder;
 use bytes::Bytes;
 use futures::{
     executor::block_on,
-    //io::AsyncReadExt,
     stream::{self, StreamExt},
 };
 use std::io::{self, Read};
@@ -27,18 +26,19 @@ fn brotli_stream() {
     assert_eq!(output, vec![1, 2, 3, 4, 5, 6]);
 }
 
-//#[test]
-//fn brotli_read() {
-//    use async_compression::read::brotli;
-//
-//    let input = &[1, 2, 3, 4, 5, 6];
-//    let compress = brotli::Compress::new();
-//    let mut compressed = brotli::compress_read(&input[..], compress);
-//    let mut data = vec![];
-//    block_on(compressed.read_to_end(&mut data)).unwrap();
-//    let mut output = vec![];
-//    BrotliDecoder::new(&data[..])
-//        .read_to_end(&mut output)
-//        .unwrap();
-//    assert_eq!(output, input);
-//}
+#[test]
+fn decompressed_brotli_stream() {
+    use async_compression::stream::brotli;
+
+    let stream = stream::iter(vec![
+        Bytes::from_static(&[1, 2, 3]),
+        Bytes::from_static(&[4, 5, 6]),
+    ]);
+    let compress = brotli::Compress::new();
+    let compressed = brotli::BrotliStream::new(stream.map(Ok), compress);
+    let decompressed = brotli::DecompressedBrotliStream::new(compressed);
+    let data: Vec<_> = block_on(decompressed.collect());
+    let data: io::Result<Vec<_>> = data.into_iter().collect();
+    let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();
+    assert_eq!(data, vec![1, 2, 3, 4, 5, 6]);
+}

--- a/tests/brotli.rs
+++ b/tests/brotli.rs
@@ -1,5 +1,5 @@
 use brotli2::bufread::{BrotliDecoder, BrotliEncoder};
-use bytes::{BufMut, Bytes, IntoBuf};
+use bytes::{Bytes, IntoBuf};
 use futures::{
     executor::block_on,
     stream::{self, StreamExt},

--- a/tests/deflate.rs
+++ b/tests/deflate.rs
@@ -27,6 +27,23 @@ fn deflate_stream() {
 }
 
 #[test]
+fn decompressed_deflate_stream() {
+    use async_compression::stream::deflate;
+
+    let stream = stream::iter(vec![
+        Bytes::from_static(&[1, 2, 3]),
+        Bytes::from_static(&[4, 5, 6]),
+    ]);
+    let compressed = deflate::DeflateStream::new(stream.map(Ok), deflate::Compression::default());
+    let decompressed = deflate::DecompressedDeflateStream::new(compressed);
+    let data: Vec<_> = block_on(decompressed.collect());
+    let data: io::Result<Vec<_>> = data.into_iter().collect();
+    let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();
+
+    assert_eq!(data, vec![1, 2, 3, 4, 5, 6]);
+}
+
+#[test]
 fn deflate_read() {
     use async_compression::read::deflate;
 

--- a/tests/deflate.rs
+++ b/tests/deflate.rs
@@ -1,4 +1,4 @@
-use bytes::{BufMut, Bytes, IntoBuf};
+use bytes::{Bytes, IntoBuf};
 use flate2::bufread::{DeflateDecoder, DeflateEncoder};
 use futures::{
     executor::block_on,

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -1,4 +1,4 @@
-use bytes::{BufMut, Bytes, IntoBuf};
+use bytes::{Bytes, IntoBuf};
 use flate2::bufread::{GzDecoder, GzEncoder};
 use futures::{
     executor::block_on,

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -1,5 +1,5 @@
-use bytes::Bytes;
-use flate2::bufread::GzDecoder;
+use bytes::{BufMut, Bytes, IntoBuf};
+use flate2::bufread::{GzDecoder, GzEncoder};
 use futures::{
     executor::block_on,
     stream::{self, StreamExt},
@@ -50,15 +50,20 @@ fn gzip_stream_large() {
 }
 
 #[test]
-fn decompressed_gzip_stream_1() {
+fn decompressed_gzip_stream_single_chunk() {
     use async_compression::stream::gzip;
 
-    let stream = stream::iter(vec![
-        Bytes::from_static(&[1, 2, 3]),
-        Bytes::from_static(&[4, 5, 6]),
-    ]);
-    let compressed = gzip::GzipStream::new(stream.map(Ok), gzip::Compression::default());
-    let decompressed = gzip::DecompressedGzipStream::new(compressed);
+    let bytes = Bytes::from_static(&[1, 2, 3, 4, 5, 6]).into_buf();
+
+    let mut gz = GzEncoder::new(bytes, gzip::Compression::default());
+    let mut buffer = Vec::new();
+
+    gz.read_to_end(&mut buffer).unwrap();
+
+    // The entirety in one chunk
+    let stream = stream::iter(vec![Bytes::from(buffer)]);
+
+    let decompressed = gzip::DecompressedGzipStream::new(stream.map(Ok));
     let data: Vec<_> = block_on(decompressed.collect());
     let data: io::Result<Vec<_>> = data.into_iter().collect();
     let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();
@@ -66,31 +71,139 @@ fn decompressed_gzip_stream_1() {
 }
 
 #[test]
-fn decompressed_gzip_stream_2() {
+fn decompressed_gzip_stream_segmented() {
     use async_compression::stream::gzip;
 
+    let bytes = Bytes::from_static(&[1, 2, 3, 4, 5, 6]).into_buf();
+
+    let mut gz = GzEncoder::new(bytes, gzip::Compression::default());
+    let mut buffer = Vec::new();
+
+    gz.read_to_end(&mut buffer).unwrap();
+
+    let body_end = buffer.len() - 8;
+
+    let header = &buffer[..10];
+    let body = &buffer[10..body_end];
+    let footer = &buffer[body_end..];
+
+    // Header, body and trailer in separate chunks, similar to how `GzipStream` outputs it.
     let stream = stream::iter(vec![
-        Bytes::from_static(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
-        Bytes::from_static(&[11, 12, 13, 14, 15]),
+        Bytes::from(&header[..]),
+        Bytes::from(&body[..]),
+        Bytes::from(&footer[..]),
     ]);
-    let compressed = gzip::GzipStream::new(stream.map(Ok), gzip::Compression::default());
-    let decompressed = gzip::DecompressedGzipStream::new(compressed);
+
+    let decompressed = gzip::DecompressedGzipStream::new(stream.map(Ok));
     let data: Vec<_> = block_on(decompressed.collect());
     let data: io::Result<Vec<_>> = data.into_iter().collect();
     let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();
-    assert_eq!(
-        data,
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-    );
+    assert_eq!(data, vec![1, 2, 3, 4, 5, 6]);
 }
 
 #[test]
-fn decompressed_gzip_stream_3() {
+fn decompressed_gzip_stream_split() {
     use async_compression::stream::gzip;
 
-    let stream = stream::iter(vec![Bytes::from_static(&[])]);
-    let compressed = gzip::GzipStream::new(stream.map(Ok), gzip::Compression::default());
-    let decompressed = gzip::DecompressedGzipStream::new(compressed);
+    let bytes = Bytes::from_static(&[1, 2, 3, 4, 5, 6]).into_buf();
+
+    let mut gz = GzEncoder::new(bytes, gzip::Compression::default());
+    let mut buffer = Vec::new();
+
+    gz.read_to_end(&mut buffer).unwrap();
+
+    let body_end = buffer.len() - 8;
+
+    let header = &buffer[..10];
+    let body = &buffer[10..body_end];
+    let footer = &buffer[body_end..];
+
+    let body_half = body.len() / 2;
+
+    // Header, body and trailer split across multiple chunks and mixed together
+    let stream = stream::iter(vec![
+        Bytes::from(&header[0..5]),
+        Bytes::from(Vec::from_iter(
+            header[5..10]
+                .iter()
+                .chain(body[0..body_half].iter())
+                .cloned(),
+        )),
+        Bytes::from(Vec::from_iter(
+            body[body_half..body_end]
+                .iter()
+                .chain(footer[0..4].iter())
+                .cloned(),
+        )),
+        Bytes::from(&footer[4..8]),
+    ]);
+
+    let decompressed = gzip::DecompressedGzipStream::new(stream.map(Ok));
+    let data: Vec<_> = block_on(decompressed.collect());
+    let data: io::Result<Vec<_>> = data.into_iter().collect();
+    let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();
+    assert_eq!(data, vec![1, 2, 3, 4, 5, 6]);
+}
+
+#[test]
+fn decompressed_gzip_stream_split_mixed() {
+    use async_compression::stream::gzip;
+
+    let bytes = Bytes::from_static(&[1, 2, 3, 4, 5, 6]).into_buf();
+
+    let mut gz = GzEncoder::new(bytes, gzip::Compression::default());
+    let mut buffer = Vec::new();
+
+    gz.read_to_end(&mut buffer).unwrap();
+
+    let body_end = buffer.len() - 8;
+
+    let header = &buffer[..10];
+    let body = &buffer[10..body_end];
+    let footer = &buffer[body_end..];
+
+    let body_half = body.len() / 2;
+
+    // Header, body and trailer each split across multiple chunks, no mixing
+    let stream = stream::iter(vec![
+        Bytes::from(&header[0..5]),
+        Bytes::from(&header[5..10]),
+        Bytes::from(&body[0..body_half]),
+        Bytes::from(&body[body_half..body_end]),
+        Bytes::from(&footer[0..4]),
+        Bytes::from(&footer[4..8]),
+    ]);
+
+    let decompressed = gzip::DecompressedGzipStream::new(stream.map(Ok));
+    let data: Vec<_> = block_on(decompressed.collect());
+    let data: io::Result<Vec<_>> = data.into_iter().collect();
+    let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();
+    assert_eq!(data, vec![1, 2, 3, 4, 5, 6]);
+}
+
+#[test]
+fn decompressed_gzip_stream_empty() {
+    use async_compression::stream::gzip;
+
+    let bytes = Bytes::from_static(&[]).into_buf();
+
+    let mut gz = GzEncoder::new(bytes, gzip::Compression::default());
+    let mut buffer = Vec::new();
+
+    gz.read_to_end(&mut buffer).unwrap();
+
+    let header = &buffer[..10];
+    let body = &buffer[10..buffer.len() - 8];
+    let footer = &buffer[buffer.len() - 8..];
+
+    // Header, body and trailer in separate chunks, similar to how `GzipStream` outputs it.
+    let stream = stream::iter(vec![
+        Bytes::from(&header[..]),
+        Bytes::from(&body[..]),
+        Bytes::from(&footer[..]),
+    ]);
+
+    let decompressed = gzip::DecompressedGzipStream::new(stream.map(Ok));
     let data: Vec<_> = block_on(decompressed.collect());
     let data: io::Result<Vec<_>> = data.into_iter().collect();
     let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -22,3 +22,51 @@ fn gzip_stream() {
     GzDecoder::new(&data[..]).read_to_end(&mut output).unwrap();
     assert_eq!(output, vec![1, 2, 3, 4, 5, 6]);
 }
+
+#[test]
+fn decompressed_gzip_stream_1() {
+    use async_compression::stream::gzip;
+
+    let stream = stream::iter(vec![
+        Bytes::from_static(&[1, 2, 3]),
+        Bytes::from_static(&[4, 5, 6]),
+    ]);
+    let compressed = gzip::GzipStream::new(stream.map(Ok), gzip::Compression::default());
+    let decompressed = gzip::DecompressedGzipStream::new(compressed);
+    let data: Vec<_> = block_on(decompressed.collect());
+    let data: io::Result<Vec<_>> = data.into_iter().collect();
+    let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();
+    assert_eq!(data, vec![1, 2, 3, 4, 5, 6]);
+}
+
+#[test]
+fn decompressed_gzip_stream_2() {
+    use async_compression::stream::gzip;
+
+    let stream = stream::iter(vec![
+        Bytes::from_static(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        Bytes::from_static(&[11, 12, 13, 14, 15]),
+    ]);
+    let compressed = gzip::GzipStream::new(stream.map(Ok), gzip::Compression::default());
+    let decompressed = gzip::DecompressedGzipStream::new(compressed);
+    let data: Vec<_> = block_on(decompressed.collect());
+    let data: io::Result<Vec<_>> = data.into_iter().collect();
+    let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();
+    assert_eq!(
+        data,
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    );
+}
+
+#[test]
+fn decompressed_gzip_stream_3() {
+    use async_compression::stream::gzip;
+
+    let stream = stream::iter(vec![Bytes::from_static(&[])]);
+    let compressed = gzip::GzipStream::new(stream.map(Ok), gzip::Compression::default());
+    let decompressed = gzip::DecompressedGzipStream::new(compressed);
+    let data: Vec<_> = block_on(decompressed.collect());
+    let data: io::Result<Vec<_>> = data.into_iter().collect();
+    let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();
+    assert_eq!(data, vec![]);
+}

--- a/tests/zlib.rs
+++ b/tests/zlib.rs
@@ -27,6 +27,23 @@ fn zlib_stream() {
 }
 
 #[test]
+fn decompressed_zlib_stream() {
+    use async_compression::stream::zlib;
+
+    let stream = stream::iter(vec![
+        Bytes::from_static(&[1, 2, 3]),
+        Bytes::from_static(&[4, 5, 6]),
+    ]);
+    let compressed = zlib::ZlibStream::new(stream.map(Ok), zlib::Compression::default());
+    let decompressed = zlib::DecompressedZlibStream::new(compressed);
+    let data: Vec<_> = block_on(decompressed.collect());
+    let data: io::Result<Vec<_>> = data.into_iter().collect();
+    let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();
+
+    assert_eq!(data, vec![1, 2, 3, 4, 5, 6]);
+}
+
+#[test]
 fn zlib_read() {
     use async_compression::read::zlib;
 

--- a/tests/zlib.rs
+++ b/tests/zlib.rs
@@ -1,4 +1,4 @@
-use bytes::{BufMut, Bytes, IntoBuf};
+use bytes::{Bytes, IntoBuf};
 use flate2::bufread::{ZlibDecoder, ZlibEncoder};
 use futures::{
     executor::block_on,

--- a/tests/zlib.rs
+++ b/tests/zlib.rs
@@ -1,5 +1,5 @@
-use bytes::Bytes;
-use flate2::bufread::ZlibDecoder;
+use bytes::{BufMut, Bytes, IntoBuf};
+use flate2::bufread::{ZlibDecoder, ZlibEncoder};
 use futures::{
     executor::block_on,
     io::AsyncReadExt,
@@ -58,12 +58,15 @@ fn zlib_stream_large() {
 fn decompressed_zlib_stream() {
     use async_compression::stream::zlib;
 
-    let stream = stream::iter(vec![
-        Bytes::from_static(&[1, 2, 3]),
-        Bytes::from_static(&[4, 5, 6]),
-    ]);
-    let compressed = zlib::ZlibStream::new(stream.map(Ok), zlib::Compression::default());
-    let decompressed = zlib::DecompressedZlibStream::new(compressed);
+    let bytes = Bytes::from_static(&[1, 2, 3, 4, 5, 6]).into_buf();
+
+    let mut gz = ZlibEncoder::new(bytes, zlib::Compression::default());
+    let mut buffer = Vec::new();
+
+    gz.read_to_end(&mut buffer).unwrap();
+
+    let stream = stream::iter(vec![Bytes::from(buffer)]);
+    let decompressed = zlib::DecompressedZlibStream::new(stream.map(Ok));
     let data: Vec<_> = block_on(decompressed.collect());
     let data: io::Result<Vec<_>> = data.into_iter().collect();
     let data: Vec<u8> = data.unwrap().into_iter().flatten().collect();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR seeks to add support for decompressing streams of encoded bytes under each of the encoding algorithms used.

This is the current progress:

- [x] Brotli
- [x] Deflate
- [x] Gzip
- [x] Zlib

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Coming up with a standard pattern of decompressing encoded streams that the library already provides would be valuable for various use cases.

It would also unblock progress on https://github.com/rustasync/tide/pull/194.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests are added.

- [x] Brotli
- [x] Deflate
- [x] Gzip
- [x] Zlib

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
