### PR TITLE
Add access to the underlying readers/streams for all encoders/decoders

### DIFF
--- a/src/bufread/deflate.rs
+++ b/src/bufread/deflate.rs
@@ -33,6 +33,35 @@ impl<R: AsyncBufRead> DeflateEncoder<R> {
             compress: Compress::new(level, false),
         }
     }
+
+    /// Acquires a reference to the underlying reader that this encoder is wrapping.
+    pub fn get_ref(&self) -> &R {
+        &self.inner
+    }
+
+    /// Acquires a mutable reference to the underlying reader that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the reader which may
+    /// otherwise confuse this encoder.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Acquires a pinned mutable reference to the underlying reader that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the reader which may
+    /// otherwise confuse this encoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut R> {
+        self.project().inner
+    }
+
+    /// Consumes this encoder returning the underlying reader.
+    ///
+    /// Note that this may discard internal state of this encoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
 }
 
 impl<R: AsyncBufRead> AsyncRead for DeflateEncoder<R> {

--- a/src/bufread/zlib.rs
+++ b/src/bufread/zlib.rs
@@ -33,6 +33,35 @@ impl<R: AsyncBufRead> ZlibEncoder<R> {
             compress: Compress::new(level, true),
         }
     }
+
+    /// Acquires a reference to the underlying reader that this encoder is wrapping.
+    pub fn get_ref(&self) -> &R {
+        &self.inner
+    }
+
+    /// Acquires a mutable reference to the underlying reader that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the reader which may
+    /// otherwise confuse this encoder.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Acquires a pinned mutable reference to the underlying reader that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the reader which may
+    /// otherwise confuse this encoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut R> {
+        self.project().inner
+    }
+
+    /// Consumes this encoder returning the underlying reader.
+    ///
+    /// Note that this may discard internal state of this encoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
 }
 
 impl<R: AsyncBufRead> AsyncRead for ZlibEncoder<R> {

--- a/src/stream/brotli.rs
+++ b/src/stream/brotli.rs
@@ -57,6 +57,35 @@ impl<S: Stream<Item = Result<Bytes>>> BrotliEncoder<S> {
             compress,
         }
     }
+
+    /// Acquires a reference to the underlying stream that this encoder is wrapping.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this encoder.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this encoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        self.project().inner
+    }
+
+    /// Consumes this encoder returning the underlying stream.
+    ///
+    /// Note that this may discard internal state of this encoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
 }
 
 impl<S: Stream<Item = Result<Bytes>>> BrotliDecoder<S> {
@@ -68,6 +97,35 @@ impl<S: Stream<Item = Result<Bytes>>> BrotliDecoder<S> {
             flush: false,
             decompress: Decompress::new(),
         }
+    }
+
+    /// Acquires a reference to the underlying stream that this decoder is wrapping.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this decoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this decoder.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this decoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this decoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        self.project().inner
+    }
+
+    /// Consumes this decoder returning the underlying stream.
+    ///
+    /// Note that this may discard internal state of this decoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.inner
     }
 }
 

--- a/src/stream/deflate.rs
+++ b/src/stream/deflate.rs
@@ -34,6 +34,35 @@ impl<S: Stream<Item = Result<Bytes>> + Unpin> DeflateEncoder<S> {
             inner: FlateEncoder::new(stream, Compress::new(level, false)),
         }
     }
+
+    /// Acquires a reference to the underlying stream that this encoder is wrapping.
+    pub fn get_ref(&self) -> &S {
+        self.inner.get_ref()
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this encoder.
+    pub fn get_mut(&mut self) -> &mut S {
+        self.inner.get_mut()
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this encoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        Pin::new(&mut self.get_mut().inner).get_pin_mut()
+    }
+
+    /// Consumes this encoder returning the underlying stream.
+    ///
+    /// Note that this may discard internal state of this encoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.inner.into_inner()
+    }
 }
 
 impl<S: Stream<Item = Result<Bytes>> + Unpin> DeflateDecoder<S> {
@@ -43,6 +72,35 @@ impl<S: Stream<Item = Result<Bytes>> + Unpin> DeflateDecoder<S> {
         DeflateDecoder {
             inner: FlateDecoder::new(stream, Decompress::new(false)),
         }
+    }
+
+    /// Acquires a reference to the underlying stream that this decoder is wrapping.
+    pub fn get_ref(&self) -> &S {
+        self.inner.get_ref()
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this decoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this decoder.
+    pub fn get_mut(&mut self) -> &mut S {
+        self.inner.get_mut()
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this decoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this decoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        Pin::new(&mut self.get_mut().inner).get_pin_mut()
+    }
+
+    /// Consumes this decoder returning the underlying stream.
+    ///
+    /// Note that this may discard internal state of this decoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.inner.into_inner()
     }
 }
 

--- a/src/stream/flate.rs
+++ b/src/stream/flate.rs
@@ -46,6 +46,22 @@ impl<S: Stream<Item = Result<Bytes>>> FlateEncoder<S> {
             compress,
         }
     }
+
+    pub(crate) fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    pub(crate) fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    pub(crate) fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        self.project().inner
+    }
+
+    pub(crate) fn into_inner(self) -> S {
+        self.inner
+    }
 }
 
 impl<S: Stream<Item = Result<Bytes>>> FlateDecoder<S> {
@@ -56,6 +72,22 @@ impl<S: Stream<Item = Result<Bytes>>> FlateDecoder<S> {
             output: BytesMut::new(),
             decompress,
         }
+    }
+
+    pub(crate) fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    pub(crate) fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    pub(crate) fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        self.project().inner
+    }
+
+    pub(crate) fn into_inner(self) -> S {
+        self.inner
     }
 }
 

--- a/src/stream/gzip.rs
+++ b/src/stream/gzip.rs
@@ -73,6 +73,35 @@ impl<S: Stream<Item = Result<Bytes>>> GzipEncoder<S> {
             compress: Compress::new(level, false),
         }
     }
+
+    /// Acquires a reference to the underlying stream that this encoder is wrapping.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this encoder.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this encoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        self.project().inner
+    }
+
+    /// Consumes this encoder returning the underlying stream.
+    ///
+    /// Note that this may discard internal state of this encoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
 }
 
 impl<S: Stream<Item = Result<Bytes>>> GzipDecoder<S> {
@@ -87,6 +116,35 @@ impl<S: Stream<Item = Result<Bytes>>> GzipDecoder<S> {
             crc: Crc::new(),
             decompress: Decompress::new(false),
         }
+    }
+
+    /// Acquires a reference to the underlying stream that this decoder is wrapping.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this decoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this decoder.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this decoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this decoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        self.project().inner
+    }
+
+    /// Consumes this decoder returning the underlying stream.
+    ///
+    /// Note that this may discard internal state of this decoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.inner
     }
 }
 

--- a/src/stream/zlib.rs
+++ b/src/stream/zlib.rs
@@ -34,6 +34,35 @@ impl<S: Stream<Item = Result<Bytes>> + Unpin> ZlibEncoder<S> {
             inner: FlateEncoder::new(stream, Compress::new(level, true)),
         }
     }
+
+    /// Acquires a reference to the underlying stream that this encoder is wrapping.
+    pub fn get_ref(&self) -> &S {
+        self.inner.get_ref()
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this encoder.
+    pub fn get_mut(&mut self) -> &mut S {
+        self.inner.get_mut()
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this encoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        Pin::new(&mut self.get_mut().inner).get_pin_mut()
+    }
+
+    /// Consumes this encoder returning the underlying stream.
+    ///
+    /// Note that this may discard internal state of this encoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.inner.into_inner()
+    }
 }
 
 impl<S: Stream<Item = Result<Bytes>> + Unpin> ZlibDecoder<S> {
@@ -43,6 +72,35 @@ impl<S: Stream<Item = Result<Bytes>> + Unpin> ZlibDecoder<S> {
         ZlibDecoder {
             inner: FlateDecoder::new(stream, Decompress::new(true)),
         }
+    }
+
+    /// Acquires a reference to the underlying stream that this decoder is wrapping.
+    pub fn get_ref(&self) -> &S {
+        self.inner.get_ref()
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this decoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this decoder.
+    pub fn get_mut(&mut self) -> &mut S {
+        self.inner.get_mut()
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this decoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this decoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        Pin::new(&mut self.get_mut().inner).get_pin_mut()
+    }
+
+    /// Consumes this decoder returning the underlying stream.
+    ///
+    /// Note that this may discard internal state of this decoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.inner.into_inner()
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
When the readers/streams are known to be some other concrete type in usage it's relatively common to want to call other methods on them that won't affect the compression (e.g. the concrete type may have a method that tells you the current position and total length so you can see how far through the stream you are).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The type system is strong enough to ensure these methods are correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
