### PR TITLE
Add access to underlying stream for zstd encoder/decoder

### DIFF
--- a/src/stream/zstd.rs
+++ b/src/stream/zstd.rs
@@ -66,6 +66,35 @@ impl<S: Stream<Item = Result<Bytes>>> ZstdEncoder<S> {
             encoder: Encoder::new(level).unwrap(),
         }
     }
+
+    /// Acquires a reference to the underlying stream that this encoder is wrapping.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this encoder.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this encoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this encoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        self.project().inner
+    }
+
+    /// Consumes this encoder returning the underlying stream.
+    ///
+    /// Note that this may discard internal state of this encoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
 }
 
 impl<S: Stream<Item = Result<Bytes>>> ZstdDecoder<S> {
@@ -78,6 +107,35 @@ impl<S: Stream<Item = Result<Bytes>>> ZstdDecoder<S> {
             output: BytesMut::new(),
             decoder: Decoder::new().unwrap(),
         }
+    }
+
+    /// Acquires a reference to the underlying stream that this decoder is wrapping.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this decoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this decoder.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this decoder is wrapping.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream which may
+    /// otherwise confuse this decoder.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
+        self.project().inner
+    }
+
+    /// Consumes this decoder returning the underlying stream.
+    ///
+    /// Note that this may discard internal state of this decoder, so care should be taken
+    /// to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.inner
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds access to the underlying stream for zstd encoders/decoders.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This follows https://github.com/rustasync/async-compression-rs/pull/15#issuecomment-491610634 -- Just wrapping it up real quick. It follows the patterns of the rest of the currently available encoders/decoders

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
