### PR TITLE
Allow using !Unpin streams with zlib/deflate

### DIFF
--- a/src/stream/deflate.rs
+++ b/src/stream/deflate.rs
@@ -3,18 +3,20 @@ use core::{
     task::{Context, Poll},
 };
 use std::io::Result;
-use std::marker::Unpin;
 
 use super::flate::{FlateDecoder, FlateEncoder};
 use bytes::Bytes;
 use flate2::{Compress, Compression, Decompress};
-use futures::{stream::Stream, stream::StreamExt};
+use futures::stream::Stream;
+use pin_project::unsafe_project;
 
 /// A DEFLATE encoder, or compressor.
 ///
 /// This structure implements a [`Stream`] interface and will read uncompressed data from an
 /// underlying stream and emit a stream of compressed data.
-pub struct DeflateEncoder<S: Stream<Item = Result<Bytes>> + Unpin> {
+#[unsafe_project(Unpin)]
+pub struct DeflateEncoder<S: Stream<Item = Result<Bytes>>> {
+    #[pin]
     inner: FlateEncoder<S>,
 }
 
@@ -22,11 +24,13 @@ pub struct DeflateEncoder<S: Stream<Item = Result<Bytes>> + Unpin> {
 ///
 /// This structure implements a [`Stream`] interface and will read compressed data from an
 /// underlying stream and emit a stream of uncompressed data.
-pub struct DeflateDecoder<S: Stream<Item = Result<Bytes>> + Unpin> {
+#[unsafe_project(Unpin)]
+pub struct DeflateDecoder<S: Stream<Item = Result<Bytes>>> {
+    #[pin]
     inner: FlateDecoder<S>,
 }
 
-impl<S: Stream<Item = Result<Bytes>> + Unpin> DeflateEncoder<S> {
+impl<S: Stream<Item = Result<Bytes>>> DeflateEncoder<S> {
     /// Creates a new encoder which will read uncompressed data from the given stream and emit a
     /// compressed stream.
     pub fn new(stream: S, level: Compression) -> DeflateEncoder<S> {
@@ -53,7 +57,7 @@ impl<S: Stream<Item = Result<Bytes>> + Unpin> DeflateEncoder<S> {
     /// Note that care must be taken to avoid tampering with the state of the stream which may
     /// otherwise confuse this encoder.
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
-        Pin::new(&mut self.get_mut().inner).get_pin_mut()
+        self.project().inner.get_pin_mut()
     }
 
     /// Consumes this encoder returning the underlying stream.
@@ -65,7 +69,7 @@ impl<S: Stream<Item = Result<Bytes>> + Unpin> DeflateEncoder<S> {
     }
 }
 
-impl<S: Stream<Item = Result<Bytes>> + Unpin> DeflateDecoder<S> {
+impl<S: Stream<Item = Result<Bytes>>> DeflateDecoder<S> {
     /// Creates a new decoder which will read compressed data from the given stream and emit an
     /// uncompressed stream.
     pub fn new(stream: S) -> DeflateDecoder<S> {
@@ -92,7 +96,7 @@ impl<S: Stream<Item = Result<Bytes>> + Unpin> DeflateDecoder<S> {
     /// Note that care must be taken to avoid tampering with the state of the stream which may
     /// otherwise confuse this decoder.
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut S> {
-        Pin::new(&mut self.get_mut().inner).get_pin_mut()
+        self.project().inner.get_pin_mut()
     }
 
     /// Consumes this decoder returning the underlying stream.
@@ -104,18 +108,18 @@ impl<S: Stream<Item = Result<Bytes>> + Unpin> DeflateDecoder<S> {
     }
 }
 
-impl<S: Stream<Item = Result<Bytes>> + Unpin> Stream for DeflateEncoder<S> {
+impl<S: Stream<Item = Result<Bytes>>> Stream for DeflateEncoder<S> {
     type Item = Result<Bytes>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
-        self.inner.poll_next_unpin(cx)
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
+        self.project().inner.poll_next(cx)
     }
 }
 
-impl<S: Stream<Item = Result<Bytes>> + Unpin> Stream for DeflateDecoder<S> {
+impl<S: Stream<Item = Result<Bytes>>> Stream for DeflateDecoder<S> {
     type Item = Result<Bytes>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
-        self.inner.poll_next_unpin(cx)
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
+        self.project().inner.poll_next(cx)
     }
 }

--- a/src/stream/flate.rs
+++ b/src/stream/flate.rs
@@ -20,7 +20,7 @@ enum State {
 }
 
 #[unsafe_project(Unpin)]
-pub(crate) struct FlateEncoder<S: Stream<Item = Result<Bytes>>> {
+pub struct FlateEncoder<S: Stream<Item = Result<Bytes>>> {
     #[pin]
     inner: S,
     state: State,
@@ -29,7 +29,7 @@ pub(crate) struct FlateEncoder<S: Stream<Item = Result<Bytes>>> {
 }
 
 #[unsafe_project(Unpin)]
-pub(crate) struct FlateDecoder<S: Stream<Item = Result<Bytes>>> {
+pub struct FlateDecoder<S: Stream<Item = Result<Bytes>>> {
     #[pin]
     inner: S,
     state: State,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove `Unpin` bounds from `ZlibEncoder`/`DeflateEncoder`.
<!--- Describe your changes in detail -->

## Motivation and Context
More general for potential usecases.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
