### PR TITLE
Add more metadata for the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = ["Wim Looman <wim@nemo157.com>", "Allen Bui <fairingrey@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
+keywords = ["compress", "compression", "flate", "deflate", "gzip", "zlib", "zstd", "zstandard", "brotli", "async", "futures"]
+categories = ["compression", "asynchronous"]
 
 [dependencies]
 brotli2 = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 keywords = ["compress", "compression", "flate", "deflate", "gzip", "zlib", "zstd", "zstandard", "brotli", "async", "futures"]
 categories = ["compression", "asynchronous"]
+repository = "https://github.com/rustasync/async-compression"
+description = """
+Adaptors between compression crates and Rust's modern asynchronous IO types.
+"""
 
 [dependencies]
 brotli2 = "0.3.2"


### PR DESCRIPTION
Add the expected metadata for discoverability and linking.

The keywords were mostly pulled from the underlying crates.